### PR TITLE
Rewriting AST in the end after getting all rewrite functions

### DIFF
--- a/testdata/sample1.golden.go
+++ b/testdata/sample1.golden.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func main() {
+	var x int
+	var a, b, c int = 1, 2, 3
+	x = int(max(int64(a), int64(b), int64(c)))
+	fmt.Println(x)
+}
+
+func max(xs ...int64) int64 {
+	x := 1
+	return int64(x)
+}

--- a/testdata/sample1.input.go
+++ b/testdata/sample1.input.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func main() {
+	var x int
+	var a, b, c int = 1, 2, 3
+	x = max(a, b, c)
+	fmt.Println(x)
+}
+
+func max(xs ...int64) int64 {
+	x := 1
+	return x
+}

--- a/testdata/sample2.golden.go
+++ b/testdata/sample2.golden.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func main() {
+	var a, b, c int = 1, 2, 3
+	var x int64 = max(int64(a), int64(b), int64(c))
+	fmt.Println(x)
+}
+
+func max(a int64, bs ...int64) int64 {
+	x := 1
+	return int64(x)
+}

--- a/testdata/sample2.input.go
+++ b/testdata/sample2.input.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func main() {
+	var a, b, c int = 1, 2, 3
+	var x int64 = int(max(a, int64(b), c))
+	fmt.Println(x)
+}
+
+func max(a int64, bs ...int64) int64 {
+	x := 1
+	return x
+}


### PR DESCRIPTION
It avoids that one rewriting AST affects next one.